### PR TITLE
Proposed additions to guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ Sometimes an Ember addon needs a new maintainer. In order to make this a consoli
 - after the checklist is complete, transfer the repo to melsumner here on Github. 
 - The addon will then be transferred to this org (Adopted Ember Addons). 
 
+** Warning: You cannot ever fork the repo to the same account it was transferred from -- it will break GitHub's redirect of the old URL to the new **
+
 ## Addon Transfer Checklist
-These are the things that need to be updated in the addon: 
-- [ ] change the package.json repository field
-- [ ] if any demo URL or homepage is referenced, it should be updated. At the very least, file an issue on the repo so the adopter can fix
+These are the things that need to done to transfer your addon: 
+- [ ] Update the package.json repository field to point to the new location
+- [ ] If any demo URL or homepage is referenced, it should be updated. At the very least, file an issue on the repo so the adopter can fix
+- [ ] Ensure Release practices are documented
+- [ ] Add `adopted-ember-addons` to the maintainers of the package on `npm`. Remove other maintainers. 
 
 ## Adopting an addon
 Anyone can submit a pull request to help maintain an addon in this repo! 


### PR DESCRIPTION
- Add to checklist to update npm maintainers, including removing themselves. Wouldn't want competing releases after transfer. This will require making an `npm` account for `adopted-ember-addons`
- Add to checklist to document Release processes
- Add a warning about forking the repo after it has been transferred