### PR TITLE
provide Netlify and GitHub Pages as unbiased choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ By standardizing some aspects of maintaining addons we can ensure a consistent e
 	
 ## Hosting and Deployments
 
-If the addon provides a documentation or demo application, it should be deployed for easier accessibility. Either <a href="https://www.netlify.com">Nelify</a> or <a href="https://pages.github.com/">GitHub Pages</a> should be used for hosting.
+If the addon provides a documentation or demo application, it should be deployed for easier accessibility. Either <a href="https://www.netlify.com">Netlify</a> or <a href="https://pages.github.com/">GitHub Pages</a> should be used for hosting.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,20 @@ By standardizing some aspects of maintaining addons we can ensure a consistent e
 ## Hosting and Deployments
 
 If the addon provides a documentation or demo application, it should be deployed for easier accessibility. Either <a href="https://www.netlify.com">Netlify</a> or <a href="https://pages.github.com/">GitHub Pages</a> should be used for hosting.
+
+## Sponsors
+
+We like to thanks the companies, which infrastructure we could use for free:
+
+[
+  ![GitHub](https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png)
+](https://github.com/)
+
+[
+  ![Travis CI](https://travis-ci.com/images/logos/TravisCI-Full-Color.png)
+](https://travis-ci.org/)
+
+<!-- Netlify badge must be present on README of the repository per requirement of their Open Source plan -->
+[
+  ![Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)
+](https://www.netlify.com)

--- a/README.md
+++ b/README.md
@@ -41,10 +41,4 @@ By standardizing some aspects of maintaining addons we can ensure a consistent e
 	
 ## Hosting and Deployments
 
-While we don't enforce a single way to host and deploy addon docs, many of the addons in this org use Netlify to deploy and host the addon docs.
-
-<a href="https://www.netlify.com">
-  <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
-</a>
-
-Another option is to use Github Pages.
+If the addon provides a documentation or demo application, it should be deployed for easier accessibility. Either <a href="https://www.netlify.com">Nelify</a> or <a href="https://pages.github.com/">GitHub Pages</a> should be used for hosting.


### PR DESCRIPTION
The current text ~states~ could be easily misinterpreted that most addons in the org uses Netlify. This wasn't matching my experience and therefore I quickly counted. 3 addons are currently using Netlify and 7 addons are using GitHub Pages. So it's more the other way around.

To be honest I'm not an expert on the topic and haven't used Netlify myself yet. There might be arguments to recommend it over GitHub Pages. But the current usage by addons in this org is more an argument for the opposite.

To avoid a opinionated discussion about the topic I propose that we present both as valid choices for now.

---

To make my numbers comprehensible here are the addons that I found grouped by their hosting. I have only considered addons that had an URL configured on GitHub.

These addons are using Netlify:

- https://github.com/adopted-ember-addons/ember-impagination
- https://github.com/adopted-ember-addons/ember-stripe-elements
- https://github.com/adopted-ember-addons/emberx-select

These addons are using GitHub Pages:

- https://github.com/adopted-ember-addons/ember-autoresize
- https://github.com/adopted-ember-addons/ember-keyboard
- https://github.com/adopted-ember-addons/ember-file-upload
- https://github.com/adopted-ember-addons/ember-sortable
- https://github.com/adopted-ember-addons/ember-page-title
- https://github.com/adopted-ember-addons/ember-collapsible-panel
- https://github.com/adopted-ember-addons/ember-electron

/cc @Alonski 