### PR TITLE
add chapters about release process and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ This document uses the keywords *must*, *must not*, *should*, *should not* and *
 
 > This terminology is based on [RFC 2119](https://tools.ietf.org/html/rfc2119), which is used by many specification documents.
 
+### Release process
+
+All addons within the org should document their release process. The documentation should be located in `RELEASE.md` file in the root folder of the repository.
+
+[Release-it](https://github.com/release-it/release-it#release-it-) should be used to automate versioning and package publishing related tasks.
+
+Addons may use the setup script [create-rwjblue-release-it-setup](https://github.com/rwjblue/create-rwjblue-release-it-setup) provided by Robert Jackson (`@rwjblue`) to setup release-it and create the release documentation.
+
+### Versioning
+
+All addons with the org must use [semantic versioning](https://semver.org/) (SemVer).
+
+Dropping support for
+
+- specific versions of Ember packages (`ember-source`, `ember-cli` and `ember-data`) or other peer dependencies,
+- node releases or
+- browser targets
+
+must be considered as breaking changes. Such changes must not be released in minor or patch versions.
+
+Deprecations may be included in a minor or patch release before removing public APIs in the next major release.
+
 ### Changelog
 
 All addons within the org should have a changelog. The changelog may not cover versions that were released before it was introduced.


### PR DESCRIPTION
This adds to new chapters:

- Release process
- Versioning

It adds the requirement to use semantic versioning. It also requires all addons to consider removing support for dependencies (ember packages, node versions, browser targets) as a breaking change. I think this is a well established standard within the Ember community.

It recommends [release-it](https://github.com/release-it/release-it#release-it-) to automate the versioning and package publication. As far as I'm aware release-it is the established tool for these tasks in the Ember community.

Some time ago [ember-cli-release](https://github.com/shipshapecode/ember-cli-release) was used by many addons. But more and more addons switched to release-it. Ember-cli-release has been [deprecated recently](https://github.com/shipshapecode/ember-cli-release/pull/79) and officially recommends to use release-it instead.

These addons within the org do not use release-it yet:

- ember-cli-sass
- ember-cli-deploy-new-relic-sourcemap
- ember-impagination
- ember-cli-ifa
- ember-page-title
- ember-notify
- emberx-select
- ember-stripe-elements
- ember-collapsible-panel
- ember-indexeddb-adapter
- ember-theme-changerr
- ember-cli-hot-loader
- ember-autoresize
- ember-cli-windows

This is a little bit more than half of the addons within the organization (14 of 21). This makes this recommendation a little bit more tough as it's not obvious from the adoption so far that it's the right way to go.

I think a unified release process is important mainly for two reasons:

1. Only a limited number of people can do a release. Due to security concerns permissions to publish NPM package should not be given to too much people. Reducing the workload on the small group will help with having short release cycles.
2. Different release processes are likely to cause failures - especially if their are not automated nor documented. Having a limited number of people being responsible to do so for many addons (21 currently) does not help with preventing such mistakes. Automation is a good tool to reduce the risk of human errors for such tasks.

Having a dedicated documentation for the release process is not very common within the ember community. But I think it's still helpful for the org: 

1. It will reduce the entry barrier for new contributors
2. It will reduce the risk of mistakes due to wrong assumptions on the process.

But to be honest a main motivator to propose that we recommend to have a `RELEASE.md` is how cheap it is thanks to [create-rwjblue-release-it-setup](https://github.com/rwjblue/create-rwjblue-release-it-setup). If using that script a release documentation that should fit for most addons comes for free.