### PR TITLE
add chapter about continuous integration (CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This document uses the keywords *must*, *must not*, *should*, *should not* and *
 
 > This terminology is based on [RFC 2119](https://tools.ietf.org/html/rfc2119), which is used by many specification documents.
 
+### Continuous Integration
+
+All addons within the org should run tests and linting automatically for all pull requests _before_ merging them and for the main branch (e.g. `master`) after merging them. They must use GitHub Actions to do so.
+
 ### Release process
 
 All addons within the org should document their release process. The documentation should be located in `RELEASE.md` file in the root folder of the repository.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,6 @@ We like to thanks the companies, which infrastructure we could use for free:
   ![GitHub](https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png)
 ](https://github.com/)
 
-[
-  ![Travis CI](https://travis-ci.com/images/logos/TravisCI-Full-Color.png)
-](https://travis-ci.org/)
-
 <!-- Netlify badge must be present on README of the repository per requirement of their Open Source plan -->
 [
   ![Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This document uses the keywords *must*, *must not*, *should*, *should not* and *
 
 ### Continuous Integration
 
-All addons within the org should run tests and linting automatically for all pull requests _before_ merging them and for the main branch (e.g. `master`) after merging them. They must use GitHub Actions to do so.
+All addons within the org should run tests and linting automatically for all pull requests _before_ merging them and for the main branch (e.g. `master`) after merging them. They must use GitHub Actions to do so. The GitHub Actions CI workflow may be generated with [create-github-actions-setup-for-ember-addon](https://github.com/jelhan/create-github-actions-setup-for-ember-addon).
 
 ### Release process
 


### PR DESCRIPTION
I think it makes sense to settle on a tool to use for CI. GitHub Actions seems to be the way to go. TravisCI is basically not useable anymore. Many addons are already migrated from TravisCI to GitHub Actions. Alternatives like CircleCI or GitLab CI are way less used with the ember community.

Addons not yet migrated to GitHub Actions should be migrated as soon as possible after merging this one. Broken CI complicates development for both contributors as well as maintainers.

I propose that we migrate the addons using [create-github-actions-setup-for-ember-addon](https://github.com/jelhan/create-github-actions-setup-for-ember-addon) if possible to avoid friction. It will help to maintain the GitHub Actions workflow until Ember provides an official solution.