### PR TITLE
Adopting Prettier for templates in the adopted-ember-addons org

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,9 @@ This document uses the keywords *must*, *must not*, *should*, *should not* and *
 
 ### Prettier
 
-All addon within the org should format the JavaScript code with [Prettier](https://prettier.io/). Prettier should be integrated as an [ESLint](https://eslint.org/) plugin. The setup and configuration should follow the [RFC 628](https://github.com/emberjs/rfcs/pull/628).
+All addons within the org should format JavaScript and Handlebars code with [Prettier](https://prettier.io/). Prettier should be integrated as an [ESLint](https://eslint.org/) plugin for JavaScrip and with [Ember Template Lint](https://github.com/ember-template-lint/ember-template-lint) for templates. The setup and configuration should follow the [RFC 628](https://github.com/emberjs/rfcs/pull/628).
 
 > Prettier is an opinionated code formatter. Using it prevents stylistic debates while maintaining addons within the org and helps both developers, reviewers and maintainers to focus on the problems the addon try to solve.
-
-Prettier should not be used to format templates (`*.hbs`) yet, due to issues with whitespace.
-
-> Prettier has experimental support for Glimmer templates. But it is not stable enough yet to be adopted by addons within the org. It's very likely that we will recommend using it for Glimmer templates as well as soon as it's stable enough. The progress is tracked in [this quest issue](https://github.com/jgwhite/prettier/issues/1).
 
 ### Continuous Integration
 


### PR DESCRIPTION
This came out of a [question I asked](https://discord.com/channels/480462759797063690/525367494400278538/912480624844087318) in the `#adopted-ember-addons` channel on Discord. As Prettier formatting of templates is [now deemed stable](https://prettier.io/blog/2021/05/09/2.3.0.html#ember--handlebars) and the whitespace issues have been resolved should we start encouraging its use for addons in the org?

Just adding this to get the conversation going.

### Disadvantages
* It's still early days in its adoption in the wider community
* It's not officially part of the blueprints for Ember apps or addons (Should I create an RFC to kick this off?)
* Additional editor configuration required to format on save, this may be a barrier to entry

### Positives
* Similar reasons why we do it for JS, there's a productivity boost from less worrying about formatting and bikeshedding style
* While an contributor's editor mightn't be set up for formatting on save it can be carried out by doing `yarn hbs:lint:fix`.
* Using Prettier for handlebars for the adopted-ember-addons may help drive adoption

/cc @jelhan @knownasilya @MelSumner @rwjblue 